### PR TITLE
Update README.md

### DIFF
--- a/http2/README.md
+++ b/http2/README.md
@@ -4,6 +4,8 @@
 
 ### Step to use HTTP2 Sampler
 
+As Java 8 does not have native support for HTTP/2, you will need to ensure you have alpn-boot on your system and edit JVM_ARGS as follows:
+
 1- Download alpn-boot according to your JVM version
 		https://www.eclipse.org/jetty/documentation/9.4.x/alpn-chapter.html
 	


### PR DESCRIPTION
Andrey,

Could we add this comment to explain why we need to install alpn-boot to use HTTP/2 plugin.