### PR TITLE
fix smack 4.0.7 can't login issue which described as NoResponseException

### DIFF
--- a/xmpp/pom.xml
+++ b/xmpp/pom.xml
@@ -57,6 +57,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
+        <smack.version>4.1.0-alpha3</smack.version>
     </properties>
     <dependencies>
         <dependency>
@@ -68,12 +69,12 @@
         <dependency>
             <groupId>org.igniterealtime.smack</groupId>
             <artifactId>smack-tcp</artifactId>
-            <version>4.0.7</version>
+            <version>${smack.version}</version>
         </dependency>
         <dependency>
             <groupId>org.igniterealtime.smack</groupId>
             <artifactId>smack-bosh</artifactId>
-            <version>4.0.7</version>
+            <version>${smack.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.igniterealtime.jbosh</groupId>
@@ -89,7 +90,22 @@
         <dependency>
             <groupId>org.igniterealtime.smack</groupId>
             <artifactId>smack-extensions</artifactId>
-            <version>4.0.7</version>
+            <version>${smack.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.igniterealtime.smack</groupId>
+            <artifactId>smack-java7</artifactId>
+            <version>${smack.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.igniterealtime.smack</groupId>
+            <artifactId>smack-sasl-provided</artifactId>
+            <version>${smack.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jxmpp</groupId>
+            <artifactId>jxmpp-stringprep-libidn</artifactId>
+            <version>0.4.0</version>
         </dependency>
 
         <dependency>

--- a/xmpp/src/main/java/com/blazemeter/jmeter/xmpp/JMeterXMPPConnection.java
+++ b/xmpp/src/main/java/com/blazemeter/jmeter/xmpp/JMeterXMPPConnection.java
@@ -38,7 +38,9 @@ public class JMeterXMPPConnection extends JMeterXMPPConnectionBase {
             if (conn.isConnected()) {
                 try {
                     log.debug("Disconnecting: " + conn.getConnectionID());
-                    conn.disconnect();
+                    if(conn instanceof AbstractXMPPConnection){
+                        ((AbstractXMPPConnection)conn).disconnect();
+                    }
                 } catch (SmackException.NotConnectedException e) {
                     log.error("Not connected, nothing to disconnect");
                 }

--- a/xmpp/src/main/java/com/blazemeter/jmeter/xmpp/actions/Connect.java
+++ b/xmpp/src/main/java/com/blazemeter/jmeter/xmpp/actions/Connect.java
@@ -3,6 +3,7 @@ package com.blazemeter.jmeter.xmpp.actions;
 
 import com.blazemeter.jmeter.xmpp.JMeterXMPPSampler;
 import org.apache.jmeter.samplers.SampleResult;
+import org.jivesoftware.smack.AbstractXMPPConnection;
 
 import javax.swing.*;
 import java.awt.*;
@@ -15,7 +16,8 @@ public class Connect extends AbstractXMPPAction {
 
     @Override
     public SampleResult perform(JMeterXMPPSampler sampler, SampleResult res) throws Exception {
-        sampler.getXMPPConnection().connect();
+        AbstractXMPPConnection conn = (AbstractXMPPConnection)sampler.getXMPPConnection();
+        conn.connect();
         res.setResponseData(sampler.getXMPPConnection().getConnectionID().getBytes());
         return res;
     }

--- a/xmpp/src/main/java/com/blazemeter/jmeter/xmpp/actions/Disconnect.java
+++ b/xmpp/src/main/java/com/blazemeter/jmeter/xmpp/actions/Disconnect.java
@@ -2,6 +2,7 @@ package com.blazemeter.jmeter.xmpp.actions;
 
 import com.blazemeter.jmeter.xmpp.JMeterXMPPSampler;
 import org.apache.jmeter.samplers.SampleResult;
+import org.jivesoftware.smack.AbstractXMPPConnection;
 
 import javax.swing.*;
 import java.awt.*;
@@ -18,8 +19,8 @@ public class Disconnect extends AbstractXMPPAction {
         if (!sampler.getXMPPConnection().isConnected()) {
             return res;
         }
-
-        sampler.getXMPPConnection().disconnect();
+        AbstractXMPPConnection conn = (AbstractXMPPConnection)sampler.getXMPPConnection();
+        conn.disconnect();
         if (sampler.getXMPPConnectionConfig() != null)
             sampler.getXMPPConnectionConfig().resetConnection();
         return res;

--- a/xmpp/src/main/java/com/blazemeter/jmeter/xmpp/actions/Login.java
+++ b/xmpp/src/main/java/com/blazemeter/jmeter/xmpp/actions/Login.java
@@ -8,6 +8,7 @@ import javax.swing.JTextField;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
+import org.jivesoftware.smack.AbstractXMPPConnection;
 import org.jivesoftware.smack.XMPPConnection;
 
 public class Login extends AbstractXMPPAction {
@@ -45,10 +46,11 @@ public class Login extends AbstractXMPPAction {
         String pwdStr = sampler.getPropertyAsString(PASSWORD);
         String resStr = sampler.getPropertyAsString(RESOURCE);
         res.setSamplerData("Username: " + loginStr + "\nPassword: " + pwdStr + "\nResource: " + resStr);
+        AbstractXMPPConnection absConn = (AbstractXMPPConnection) conn;
         if (loginStr.isEmpty()) {
-            conn.loginAnonymously();
+            absConn.loginAnonymously();
         } else {
-            conn.login(loginStr, pwdStr, resStr);
+            absConn.login(loginStr, pwdStr, resStr);
         }
         return res;
     }

--- a/xmpp/src/main/java/com/blazemeter/jmeter/xmpp/actions/NoOp.java
+++ b/xmpp/src/main/java/com/blazemeter/jmeter/xmpp/actions/NoOp.java
@@ -54,7 +54,7 @@ public class NoOp extends AbstractXMPPAction implements PacketListener {
                 subRes.setSuccessful(false);
                 subRes.setResponseCode("500");
                 subRes.setResponseMessage(packet.getError().toString());
-            } else if ((packet instanceof IQ) && (((IQ) packet).getType() == IQ.Type.ERROR)) {
+            } else if ((packet instanceof IQ) && (((IQ) packet).getType() == IQ.Type.error)) {
                 subRes.setSuccessful(false);
                 subRes.setResponseCode("500");
                 subRes.setResponseMessage(packet.getError().toString());

--- a/xmpp/src/main/java/com/blazemeter/jmeter/xmpp/actions/SendFileXEP0096.java
+++ b/xmpp/src/main/java/com/blazemeter/jmeter/xmpp/actions/SendFileXEP0096.java
@@ -125,7 +125,7 @@ public class SendFileXEP0096 extends AbstractXMPPAction implements FileTransferL
 
     @Override
     public void connected(XMPPConnection connection) {
-        this.mgr = new FileTransferManager(connection);
+        this.mgr = FileTransferManager.getInstanceFor(connection);
         mgr.addFileTransferListener(this);
     }
 

--- a/xmpp/src/main/java/com/blazemeter/jmeter/xmpp/actions/SendMessage.java
+++ b/xmpp/src/main/java/com/blazemeter/jmeter/xmpp/actions/SendMessage.java
@@ -10,13 +10,10 @@ import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.Packet;
-import org.jivesoftware.smack.util.StringUtils;
-import org.jivesoftware.smackx.delay.packet.DelayInfo;
-import org.jivesoftware.smackx.delay.packet.DelayInformation;
+import org.jxmpp.util.XmppStringUtils;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -31,7 +28,7 @@ public class SendMessage extends AbstractXMPPAction implements PacketListener, C
 
     public static final String NEED_RESPONSE_MARKER = "ExpectedResponseMarker";
     public static final String RESPONSE_MARKER = "ProvidedResponseMarker";
-    private final static String NS_DELAYED = (new DelayInfo(new DelayInformation(new Date()))).getNamespace();
+    private final static String NS_DELAYED = "urn:xmpp:delay";
 
     private JTextField msgRecipient;
     private JTextArea msgBody;
@@ -76,7 +73,7 @@ public class SendMessage extends AbstractXMPPAction implements PacketListener, C
             while (packets.hasNext()) {
                 Packet packet = packets.next();
                 Message response = (Message) packet;
-                if (StringUtils.parseBareAddress(response.getFrom()).equals(recipient)) {
+                if (XmppStringUtils.parseBareAddress(response.getFrom()).equals(recipient)) {
                     packets.remove();
                     res.setResponseData(response.toXML().toString().getBytes());
                     if (response.getError() != null) {

--- a/xmpp/src/test/java/com/blazemeter/jmeter/xmpp/JMeterXMPPSamplerTest.java
+++ b/xmpp/src/test/java/com/blazemeter/jmeter/xmpp/JMeterXMPPSamplerTest.java
@@ -90,7 +90,7 @@ public class JMeterXMPPSamplerTest {
 
         for (int a = 0; a < 2; a++) {
             doAction(obj, Connect.class);
-            SASLAuthentication.getRegisterSASLMechanisms();
+            SASLAuthentication.getRegisterdSASLMechanisms();
             doAction(obj, Login.class);
             //Thread.sleep(500);
             doAction(obj, Disconnect.class);

--- a/xmpp/src/test/java/com/blazemeter/jmeter/xmpp/XMPPConnectionMock.java
+++ b/xmpp/src/test/java/com/blazemeter/jmeter/xmpp/XMPPConnectionMock.java
@@ -4,10 +4,11 @@ import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
 import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.packet.Packet;
+import org.jivesoftware.smack.packet.PlainStreamElement;
 
 import java.io.IOException;
 
-public class XMPPConnectionMock extends XMPPConnection {
+public class XMPPConnectionMock extends AbstractXMPPConnection {
     private static final Logger log = LoggingManager.getLoggerForClass();
 
     public boolean isConnected = true;
@@ -50,6 +51,11 @@ public class XMPPConnectionMock extends XMPPConnection {
     @Override
     protected void sendPacketInternal(Packet packet) throws SmackException.NotConnectedException {
         log.debug("Emul sending packet: " + packet.toXML());
+    }
+
+    @Override
+    public void send(PlainStreamElement element) throws SmackException.NotConnectedException {
+        log.debug("Emul sending packet: " + element.toXML());
     }
 
     @Override


### PR DESCRIPTION
When attempt to login against ejabberd 17.11, it response with like below:

> Exception in thread "main" org.jivesoftware.smack.SmackException$NoResponseException
> at org.jivesoftware.smack.PacketCollector.nextResultOrThrow(PacketCollector.java:1 91)
> at org.jivesoftware.smack.PacketCollector.nextResultOrThrow(PacketCollector.java:1 75)
> at org.jivesoftware.smack.XMPPConnection.bindResourceAndEstablishSession(XMPPConne ction.java:530)
> at org.jivesoftware.smack.tcp.XMPPTCPConnection.login(XMPPTCPConnection.java:260)

the issue also described here: https://discourse.igniterealtime.org/t/smack-4-0-4-communigate-pro-login-issue/72716/6

For workaround this, upgrade smack version to 4.1.0-alpha3 which fix the issue and has no significant change.