### PR TITLE
handle variant streams with no resolution tag

### DIFF
--- a/hls/pom.xml
+++ b/hls/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>2.8.47</version>
+			<version>2.10.0</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/hls/pom.xml
+++ b/hls/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.blazemeter.jmeter</groupId>
 	<artifactId>jmeter-hls</artifactId>
-	<version>1.0.3</version>
+	<version>1.2-ramp</version>
 
 	<build>
 		<plugins>

--- a/hls/src/main/java/com/blazemeter/jmeter/hls/logic/HlsSampler.java
+++ b/hls/src/main/java/com/blazemeter/jmeter/hls/logic/HlsSampler.java
@@ -87,9 +87,9 @@ public class HlsSampler extends AbstractSampler {
 		if (playlistUri.startsWith("http")) {
 			playlist = playlistUri;
 		} else if (playlistUri.indexOf('/') == 0) {
-			playlist = getPRotocol() + "://" + masterURL.getHost() + playlistUri;// "https://"
+			playlist = getPRotocol() + "://" + masterURL.getHost() + (masterURL.getPort() > 0 ? ":" + masterURL.getPort() : "") + playlistUri;// "https://"
 		} else {
-			playlist = getPRotocol() + "://" + masterURL.getHost() + auxPath + playlistUri;
+			playlist = getPRotocol() + "://" + masterURL.getHost() + (masterURL.getPort() > 0 ? ":" + masterURL.getPort() : "") + auxPath + playlistUri;
 		}
 
 		auxPath = getPRotocol() + "://" + masterURL.getHost() + (masterURL.getPort() > 0 ? ":" + masterURL.getPort() : "") + auxPath;
@@ -314,7 +314,7 @@ public class HlsSampler extends AbstractSampler {
 			if ((url != null) && (!uriString.startsWith("http"))) {
 				uriString = url + uriString;
 			}
-			log.info("fragment URI: " + uriString);
+			//log.info("fragment URI: " + uriString);
 			
 			result.sampleStart();
 

--- a/hls/src/main/java/com/blazemeter/jmeter/hls/logic/HlsSampler.java
+++ b/hls/src/main/java/com/blazemeter/jmeter/hls/logic/HlsSampler.java
@@ -77,12 +77,13 @@ public class HlsSampler extends AbstractSampler {
 
 	private String getPlaylistPath(DataRequest respond, Parser parser) throws MalformedURLException {
 		URL masterURL = new URL(getURLData());
-		playlistUri = parser.extractUriMaster(respond.getResponse(), this.getRESDATA(), this.getNetwordData(),
+		playlistUri = parser.extractMediaUrl(respond.getResponse(), this.getRESDATA(), this.getNetwordData(),
 				this.getBandwidthType(), this.getResolutionType());
 		String auxPath = masterURL.getPath().substring(0, masterURL.getPath().lastIndexOf('/') + 1);
-
-		if(playlistUri.trim().equals(""))
+		
+		if(playlistUri == null)
 			playlistUri = getURLData();
+
 		if (playlistUri.startsWith("http")) {
 			playlist = playlistUri;
 		} else if (playlistUri.indexOf('/') == 0) {
@@ -91,7 +92,7 @@ public class HlsSampler extends AbstractSampler {
 			playlist = getPRotocol() + "://" + masterURL.getHost() + auxPath + playlistUri;
 		}
 
-		auxPath = getPRotocol() + "://" + masterURL.getHost() + auxPath;
+		auxPath = getPRotocol() + "://" + masterURL.getHost() + (masterURL.getPort() > 0 ? ":" + masterURL.getPort() : "") + auxPath;
 
 		return auxPath;
 
@@ -163,8 +164,9 @@ public class HlsSampler extends AbstractSampler {
 
 				if (firstTime) {
 					if (!(((getHlsVideoType().equals("live")) && (parser.isLive(subRespond.getResponse())))
-							|| ((isVod) && (!parser.isLive(subRespond.getResponse())))
-							|| ((getHlsVideoType().equals("event")) && (parser.isLive(subRespond.getResponse()))))) {
+					      || ((isVod) && (!parser.isLive(subRespond.getResponse())))
+					      || ((getHlsVideoType().equals("event")) && (parser.isLive(subRespond.getResponse()))))) {
+					    
 					} else {
 						firstTime = false;
 						out = isVod;
@@ -312,7 +314,8 @@ public class HlsSampler extends AbstractSampler {
 			if ((url != null) && (!uriString.startsWith("http"))) {
 				uriString = url + uriString;
 			}
-
+			log.info("fragment URI: " + uriString);
+			
 			result.sampleStart();
 
 			try {

--- a/hls/src/main/java/com/blazemeter/jmeter/hls/logic/Parser.java
+++ b/hls/src/main/java/com/blazemeter/jmeter/hls/logic/Parser.java
@@ -121,20 +121,21 @@ public class Parser implements Serializable {
 
     private boolean resolutionOK(String streamResolution, String currentResolution, String matchMode, String customResolution){
 	log.info("resolutionOK: " + streamResolution + ", " + currentResolution + ", " + matchMode + ", " + currentResolution);
-	if(matchMode.equalsIgnoreCase("customresolution")){
+
+	if(matchMode.equalsIgnoreCase("customResolution")){
 	    if (customResolution != null) {
 		return customResolution.equals(streamResolution);
 	    }
-	    log.error("selection mode is CUSTOM, but no custom resolution set");
+	    log.error("selection mode is customResolution, but no custom resolution set");
 	    return false;
-	} else if(matchMode.equalsIgnoreCase("minresolution")){
+	} else if(matchMode.equalsIgnoreCase("minResolution")){
 	    if (currentResolution == null) {
 		return true;
 	    } else {
 		if (streamResolution == null) return false;
 		return (resolutionCompare(streamResolution,currentResolution) <= 0);
 	    }
-	} else if(matchMode.equalsIgnoreCase("maxresolution")){
+	} else if(matchMode.equalsIgnoreCase("maxResolution")){
 	    if (currentResolution == null) {
 		return true;
 	    } else {
@@ -149,8 +150,8 @@ public class Parser implements Serializable {
     
     public String extractMediaUrl(String playlistData, String customResolution, String customBandwidth, String bwSelected, String resSelected) {
 	String streamPattern = "(EXT-X-STREAM-INF.*)\\n(.*\\.m3u8.*)";
-	String bandwidthPattern = "[:|,]BANDWIDTH=(\\d*)";
-	String resolutionPattern = "[:|,]RESOLUTION=(\\d*x\\d*)";
+	String bandwidthPattern = "[:|,]BANDWIDTH=(\\d+)";
+	String resolutionPattern = "[:|,]RESOLUTION=(\\d+x\\d+)";
 
 	return getMediaUrl(streamPattern, bandwidthPattern, resolutionPattern, playlistData, customResolution, customBandwidth, bwSelected, resSelected);
     }
@@ -190,6 +191,7 @@ public class Parser implements Serializable {
 		}
 	    } else if (bwSelected.equalsIgnoreCase("minBandwidth")) {
 		if (curBandwidth == null || (Integer.parseInt(mb.group(1)) <= Integer.parseInt(curBandwidth))) {
+		    curBandwidth = mb.group(1);
 		    if (resolutionOK((rfound?mr.group(1):null), curResolution, resSelected, customResolution)) {
 			curResolution =(rfound?mr.group(1):null);
 			uri = m.group(2);
@@ -198,6 +200,7 @@ public class Parser implements Serializable {
 
 	    } else if (bwSelected.equalsIgnoreCase("maxBandwidth")) {
 		if (curBandwidth == null || (Integer.parseInt(mb.group(1)) >= Integer.parseInt(curBandwidth))) {
+		    curBandwidth = mb.group(1);
 		    if (resolutionOK((rfound?mr.group(1):null), curResolution, resSelected, customResolution)) {
 			curResolution = (rfound?mr.group(1):null);
 			uri = m.group(2);

--- a/hls/src/main/java/com/blazemeter/jmeter/hls/logic/Parser.java
+++ b/hls/src/main/java/com/blazemeter/jmeter/hls/logic/Parser.java
@@ -196,7 +196,7 @@ public class Parser implements Serializable {
 		}
 
 	    } else if (bwSelected.equalsIgnoreCase("maxBandwidth")) {
-		if (curBandwidth == null || Integer.parseInt(mb.group(1)) >= Integer.parseInt(curBandwidth)) {
+		if (curBandwidth == null || (Integer.parseInt(mb.group(1)) >= Integer.parseInt(curBandwidth))) {
 		    if (resolutionOK((rfound?mr.group(1):null), curResolution, resSelected, customResolution)) {
 			curResolution = (rfound?mr.group(1):null);
 			uri = m.group(2);

--- a/hls/src/main/java/com/blazemeter/jmeter/hls/logic/Parser.java
+++ b/hls/src/main/java/com/blazemeter/jmeter/hls/logic/Parser.java
@@ -120,6 +120,7 @@ public class Parser implements Serializable {
     }
 
     private boolean resolutionOK(String streamResolution, String currentResolution, String matchMode, String customResolution){
+	log.info("resolutionOK: " + streamResolution + ", " + currentResolution + ", " + matchMode + ", " + currentResolution);
 	if(matchMode.equalsIgnoreCase("customresolution")){
 	    if (customResolution != null) {
 		return customResolution.equals(streamResolution);

--- a/hls/src/main/java/com/blazemeter/jmeter/hls/logic/Parser.java
+++ b/hls/src/main/java/com/blazemeter/jmeter/hls/logic/Parser.java
@@ -12,328 +12,216 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.jorphan.logging.LoggingManager;
+import org.apache.log.Logger;
 
 import static org.apache.http.protocol.HTTP.USER_AGENT;
 
 public class Parser implements Serializable {
+    private static final Logger log = LoggingManager.getLoggerForClass();
 
+    public Parser() {
+    }
 
-	public Parser() {
+    // HTTP GET request
+    public DataRequest getBaseUrl(URL url, SampleResult sampleResult, boolean setRequest) throws IOException {
+
+	HttpURLConnection con = null;
+	DataRequest result = new DataRequest();
+	boolean first = true;
+	long sentBytes = 0;
+
+	con = (HttpURLConnection) url.openConnection();
+
+	sampleResult.connectEnd();
+
+	// By default it is GET request
+	con.setRequestMethod("GET");
+
+	// add request header
+	con.setRequestProperty("User-Agent", USER_AGENT);
+
+	// Set request header
+	result.setRequestHeaders(con.getRequestMethod() + "  " + url.toString() + "\n");
+
+	int responseCode = con.getResponseCode();
+
+	// Reading response from input Stream
+	BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+
+	String inputLine;
+	StringBuffer response = new StringBuffer();
+
+	while ((inputLine = in.readLine()) != null) {
+
+	    if (setRequest)
+		response.append(inputLine + "\n");
+
+	    sentBytes += inputLine.getBytes().length + 1;
+
+	    if (first) {
+		sampleResult.latencyEnd();
+		first = false;
+	    }
 	}
 
+	in.close();
 
-	// HTTP GET request
-	public DataRequest getBaseUrl(URL url, SampleResult sampleResult, boolean setRequest) throws IOException {
+	// Set response parameters
+	result.setHeaders(con.getHeaderFields());
+	result.setResponse(response.toString());
+	result.setResponseCode(String.valueOf(responseCode));
+	result.setResponseMessage(con.getResponseMessage());
+	result.setContentType(con.getContentType());
+	result.setSuccess(isSuccessCode(responseCode));
+	result.setSentBytes(sentBytes);
+	result.setContentEncoding(getEncoding(con));
 
-		HttpURLConnection con = null;
-		DataRequest result = new DataRequest();
-		boolean first = true;
-		long sentBytes = 0;
+	return result;
 
-		con = (HttpURLConnection) url.openConnection();
+    }
 
-		sampleResult.connectEnd();
+    public String getEncoding(HttpURLConnection connection) {
+	String contentType = connection.getContentType();
+	String[] values = contentType.split(";"); // values.length should be 2
+	String charset = "";
 
-		// By default it is GET request
-		con.setRequestMethod("GET");
+	for (String value : values) {
+	    value = value.trim();
 
-		// add request header
-		con.setRequestProperty("User-Agent", USER_AGENT);
+	    if (value.toLowerCase().startsWith("charset=")) {
+		charset = value.substring("charset=".length());
+	    }
+	}
 
-		// Set request header
-		result.setRequestHeaders(con.getRequestMethod() + "  " + url.toString() + "\n");
+	return charset;
+    }
 
-		int responseCode = con.getResponseCode();
 
-		// Reading response from input Stream
-		BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+    public List<DataFragment> extractVideoUrl(String playlistUrl) {
+	String pattern = "EXTINF:(\\d+\\.?\\d*).*\\n(#.*:.*\\n)*(.*\\.ts(\\?.*\\n*)?)";
+	final List<DataFragment> mediaList = new ArrayList<>();
+	Pattern r = Pattern.compile(pattern);
+	Matcher m = r.matcher(playlistUrl);
+	while (m.find()) {
+	    DataFragment data = new DataFragment(m.group(1), m.group(3));
+	    log.info("index: " + m.group(1) + " fragment: " + m.group(3));
+	    mediaList.add(data);
+	}
+	return mediaList;
+    }
 
-		String inputLine;
-		StringBuffer response = new StringBuffer();
+    private int resolutionCompare(String r1, String r2) {
+	String[] r1Dimensions = r1.split("x");
+	String[] r2Dimensions = r2.split("x");
+	int a1 = Integer.parseInt(r1Dimensions[0]) * Integer.parseInt(r1Dimensions[1]);
+	int a2 = Integer.parseInt(r2Dimensions[0]) * Integer.parseInt(r2Dimensions[1]);
+	return Integer.compare(a1,a2);
+    }
 
-		while ((inputLine = in.readLine()) != null) {
+    private boolean resolutionOK(String streamResolution, String currentResolution, String matchMode, String customResolution){
+	if(matchMode.equalsIgnoreCase("customresolution")){
+	    if (customResolution != null) {
+		return customResolution.equals(streamResolution);
+	    }
+	    log.error("selection mode is CUSTOM, but no custom resolution set");
+	    return false;
+	} else if(matchMode.equalsIgnoreCase("minresolution")){
+	    if (currentResolution == null) {
+		return true;
+	    } else {
+		if (streamResolution == null) return false;
+		return (resolutionCompare(streamResolution,currentResolution) <= 0);
+	    }
+	} else if(matchMode.equalsIgnoreCase("maxresolution")){
+	    if (currentResolution == null) {
+		return true;
+	    } else {
+		if (streamResolution == null) return false;
+		return (resolutionCompare(streamResolution,currentResolution) >= 0);
+	    }
 
-			if (setRequest)
-				response.append(inputLine + "\n");
+	}
+	log.error("unknown resolution selection mode");
+	return false;
+    }
+    
+    public String extractMediaUrl(String playlistData, String customResolution, String customBandwidth, String bwSelected, String resSelected) {
+	String streamPattern = "(EXT-X-STREAM-INF.*)\\n(.*\\.m3u8.*)";
+	String bandwidthPattern = "[:|,]BANDWIDTH=(\\d*)";
+	String resolutionPattern = "[:|,]RESOLUTION=(\\d*x\\d*)";
 
-			sentBytes += inputLine.getBytes().length + 1;
+	return getMediaUrl(streamPattern, bandwidthPattern, resolutionPattern, playlistData, customResolution, customBandwidth, bwSelected, resSelected);
+    }
 
-			if (first) {
-				sampleResult.latencyEnd();
-				first = false;
-			}
+
+    public String getMediaUrl(String streamPattern, String bandwidthPattern, String resolutionPattern, String playlistData,
+			      String customResolution, String customBandwidth, String bwSelected, String resSelected) {
+	String bandwidthMax ="100000000";
+	String resolutionMin = "100x100";
+	String resolutionMax = "5000x5000";
+	String curBandwidth = null;
+	String curResolution = null;
+	String uri = null;
+		
+	Pattern s = Pattern.compile(streamPattern);
+	Matcher m = s.matcher(playlistData);
+
+	Pattern b = Pattern.compile(bandwidthPattern);
+	Pattern r = Pattern.compile(resolutionPattern);
+		
+	while (m.find()) {
+	    Matcher mr = r.matcher(m.group(1));
+	    boolean rfound = mr.find();
+	    Matcher mb = b.matcher(m.group(1));
+	    boolean bfound = mb.find();
+
+	    if (! bfound) {
+		continue;
+	    }
+
+	    if (bwSelected.equalsIgnoreCase("customBandwidth")) {
+		if (Integer.parseInt(mb.group(1)) == Integer.parseInt(customBandwidth)) {
+		    if (resolutionOK((rfound?mr.group(1):null), curResolution, resSelected, customResolution)) {
+			curResolution = (rfound?mr.group(1):null);
+			uri = m.group(2);
+		    }
+		}
+	    } else if (bwSelected.equalsIgnoreCase("minBandwidth")) {
+		if (curBandwidth == null || (Integer.parseInt(mb.group(1)) <= Integer.parseInt(curBandwidth))) {
+		    if (resolutionOK((rfound?mr.group(1):null), curResolution, resSelected, customResolution)) {
+			curResolution =(rfound?mr.group(1):null);
+			uri = m.group(2);
+		    }
 		}
 
-		in.close();
-
-		// Set response parameters
-		result.setHeaders(con.getHeaderFields());
-		result.setResponse(response.toString());
-		result.setResponseCode(String.valueOf(responseCode));
-		result.setResponseMessage(con.getResponseMessage());
-		result.setContentType(con.getContentType());
-		result.setSuccess(isSuccessCode(responseCode));
-		result.setSentBytes(sentBytes);
-		result.setContentEncoding(getEncoding(con));
-
-		return result;
-
-	}
-
-	public String getEncoding(HttpURLConnection connection) {
-		String contentType = connection.getContentType();
-		String[] values = contentType.split(";"); // values.length should be 2
-		String charset = "";
-
-		for (String value : values) {
-			value = value.trim();
-
-			if (value.toLowerCase().startsWith("charset=")) {
-				charset = value.substring("charset=".length());
-			}
+	    } else if (bwSelected.equalsIgnoreCase("maxBandwidth")) {
+		if (curBandwidth == null || Integer.parseInt(mb.group(1)) >= Integer.parseInt(curBandwidth)) {
+		    if (resolutionOK((rfound?mr.group(1):null), curResolution, resSelected, customResolution)) {
+			curResolution = (rfound?mr.group(1):null);
+			uri = m.group(2);
+		    }
 		}
 
-		return charset;
-	}
-
-
-	public String extractUriMaster(String res, String resolution, String bandwidth, String bandSelected, String resolSelected) {
-		String pattern = "(EXT-X-STREAM-INF.*)\\n(.*\\.m3u8.*)";
-		String bandwidthPattern = "[:|,]BANDWIDTH=(\\d*)";
-		String resolutionPattern = "[:|,]RESOLUTION=(\\d*x\\d*)";
-
-		return getResolutionUrl(pattern, bandwidthPattern, resolutionPattern, res, resolution, bandwidth, bandSelected, resolSelected);
-	}
-
-	public List<DataFragment> extractVideoUrl(String playlistUrl) {
-
-		String pattern = "EXTINF:(\\d?\\d*\\.*\\d*).*\\n(#.*:.*\\n)*(.*\\.ts(\\?.*\\n*)*)";// "EXTINF:(\\d?\\d*\\.\\d*).*\\n(#.*:.*\\n)*(.*\\.ts)";
-		final List<DataFragment> mediaList = new ArrayList<>();
-		Pattern r = Pattern.compile(pattern);
-		Matcher m = r.matcher(playlistUrl);
-		while (m.find()) {
-			DataFragment data = new DataFragment(m.group(1), m.group(3));
-			mediaList.add(data);
-		}
-		return mediaList;
-	}
-
-
-	public String getResolutionUrl(String pattern, String bandwidthPattern, String resolutionPattern, String res,
-			String resolution, String bandwidth, String bandSelected, String resolSelected) {
-		String bandwidthMax ="100000000";
-		String secBandwidth = " ";
-		String secResolution = " ";
-		String resolutionMin = "100x100";
-		String resolutionMax = "5000x5000";
-		String uri = "";
-		Pattern r = Pattern.compile(pattern);
-
-		Pattern b = Pattern.compile(bandwidthPattern);
-		Pattern reso = Pattern.compile(resolutionPattern);
-		Matcher m = r.matcher(res);
-		boolean out = false;
-		while (m.find()) {
-
-			Matcher mreso = reso.matcher(m.group(1));
-			mreso.find();
-			Matcher mb = b.matcher(m.group(1));
-			mb.find();
-
-			Matcher mResolution = reso.matcher(m.toString());
-			Matcher mBandwidth = b.matcher(m.toString());
-
-			if (resolSelected.equalsIgnoreCase("customResolution") && mResolution.find()) {
-				if (bandSelected.equalsIgnoreCase("customBandwidth")) {
-					if (mreso.group(1).equals(resolution)) {
-						uri = m.group(2);
-						break;
-					} else if ((findResolution(resolution, secResolution, mreso.group(1)))) {
-							secResolution = mreso.group(1);
-							uri = m.group(2);
-
-							if ((Integer.parseInt(mb.group(1)) == Integer.parseInt(bandwidth))
-									|| selectBandwidth(bandwidth, mb.group(1))) {
-								secBandwidth = mb.group(1);
-								uri = m.group(2);
-							}
-						}
-
-
-				} else if (bandSelected.equalsIgnoreCase("minBandwidth")) {
-					if ((secResolution.equals(" ") && smaller(resolution, mreso.group(1)))
-							|| (!secResolution.equals(" ")
-									&& findResolution(resolution, secResolution, mreso.group(1)))) {
-						secResolution = mreso.group(1);
-					}
-					if (secBandwidth.equals(" ") && selectBandwidth(mb.group(1), bandwidthMax)
-							|| (!secBandwidth.equals(" ") && selectBandwidth(mb.group(1), secBandwidth))) {
-						secBandwidth = mb.group(1);
-						uri = m.group(2);
-					}
-
-				} else if (bandSelected.equalsIgnoreCase("maxBandwidth")) {
-					if ((secResolution.equals(" ") && smaller(resolution, mreso.group(1)))
-							|| (!secResolution.equals(" ")
-									&& findResolution(resolution, secResolution, mreso.group(1)))) {
-						secResolution = mreso.group(1);
-					}
-					if (secBandwidth.equals(" ") && !selectBandwidth( bandwidthMax, mb.group(1))
-							|| (!secBandwidth.equals(" ") && selectBandwidth( bandwidthMax, mb.group(1)))) {
-						secBandwidth = mb.group(1);
-						uri = m.group(2);
-					}
-				}
-
-			} else if (resolSelected.equalsIgnoreCase("minResolution") && mResolution.find()) {
-
-				if (bandSelected.equalsIgnoreCase("customBandwidth")) {
-
-					if ((secResolution.equals(" ") && smaller(resolutionMax, mreso.group(1)))
-							|| (!secResolution.equals(" ") && smaller(secResolution, mreso.group(1)))) {
-						secResolution = mreso.group(1);
-						secBandwidth = mb.group(1);
-						uri = m.group(2);
-					} else if (secResolution.equals(mreso.group(1))) {
-						if ((Integer.parseInt(mb.group(1)) == Integer.parseInt(bandwidth))
-								|| selectBandwidth(mb.group(1), secBandwidth))
-							secBandwidth = mb.group(1);
-						uri = m.group(2);
-					}
-
-				} else if (bandSelected.equalsIgnoreCase("minBandwidth")) {
-
-					if ((secResolution.equals(" ") && smaller(resolutionMax, mreso.group(1)))
-							|| (!secResolution.equals(" ") && smaller(secResolution, mreso.group(1)))) {
-						secResolution = mreso.group(1);
-
-						if (secBandwidth.equals(" ") && selectBandwidth(mb.group(1), bandwidthMax)
-								|| (!secBandwidth.equals(" ") && selectBandwidth(mb.group(1), secBandwidth))) {
-							secBandwidth = mb.group(1);
-							uri = m.group(2);
-						}
-					}
-
-				} else if (bandSelected.equalsIgnoreCase("maxBandwidth")) {
-					if ((secResolution.equals(" ") && smaller(resolutionMax, mreso.group(1)))
-							|| (!secResolution.equals(" ") && smaller(secResolution, mreso.group(1)))) {
-						secResolution = mreso.group(1);
-
-						if (secBandwidth.equals(" ") && !selectBandwidth(bandwidthMax, mb.group(1))
-								|| (!secBandwidth.equals(" ") && selectBandwidth(secBandwidth, mb.group(1)))) {
-							secBandwidth = mb.group(1);
-							uri = m.group(2);
-						}
-					}
-				}
-			} else if (resolSelected.equalsIgnoreCase("maxResolution") && mResolution.find()) {
-				if (bandSelected.equalsIgnoreCase("customBandwidth")) {
-
-							if ((secResolution.equals(" ") && smaller(resolutionMax, mreso.group(1)))
-									|| (!secResolution.equals(" ") && (!smaller(secResolution, mreso.group(1))))) {
-								secResolution = mreso.group(1);
-								secBandwidth = mb.group(1);
-								uri = m.group(2);
-							} else if (secResolution.equals(mreso.group(1))) {
-								if ((Integer.parseInt(mb.group(1)) == Integer.parseInt(bandwidth))
-										|| selectBandwidth(mb.group(1), secBandwidth))
-									secBandwidth = mb.group(1);
-								uri = m.group(2);
-							}
-
-				} else if (bandSelected.equalsIgnoreCase("minBandwidth")) {
-					if ((secResolution.equals(" ") && smaller(resolutionMax, mreso.group(1)))
-							|| (!secResolution.equals(" ") && smaller(secResolution, mreso.group(1)))) {
-						secResolution = mreso.group(1);
-
-						if (secBandwidth.equals(" ") && selectBandwidth(mb.group(1), bandwidthMax)
-								|| (!secBandwidth.equals(" ") && selectBandwidth(mb.group(1), secBandwidth))) {
-							secBandwidth = mb.group(1);
-							uri = m.group(2);
-						}
-					}
-				} else if (bandSelected.equalsIgnoreCase("maxBandwidth")) {
-
-					if ((secResolution.equals(" ") && smaller(resolutionMax, mreso.group(1)))
-							|| (!secResolution.equals(" ") && smaller(secResolution, mreso.group(1)))) {
-						secResolution = mreso.group(1);
-
-						if (secBandwidth.equals(" ") && !selectBandwidth(bandwidthMax, mb.group(1))
-								|| (!secBandwidth.equals(" ") && selectBandwidth(secBandwidth, mb.group(1)))) {
-							secBandwidth = mb.group(1);
-							uri = m.group(2);
-						}
-					}
-				}
-			}
-
-		}
-		return uri;
+	    } else {
+		log.error("unknown bandwidth selection mode");
+	    }
 
 	}
+	return uri;
 
-	public boolean isLive(String playlistUrl) {
-		String pattern1 = "EXT-X-ENDLIST";
-		Pattern r1 = Pattern.compile(pattern1);
-		Matcher m1 = r1.matcher(playlistUrl);
+    }
 
-		return !m1.find();
-	}
+    public boolean isLive(String playlistUrl) {
+	String pattern1 = "EXT-X-ENDLIST";
+	Pattern r1 = Pattern.compile(pattern1);
+	Matcher m1 = r1.matcher(playlistUrl);
 
-	public boolean findResolution(String target, String candidate1, String candidate2) {
-		boolean ret = false;
+	return !m1.find();
+    }
 
-		if (candidate1.trim().equals("")) {
-			return true;
-		} else {
-			String[] targetWords = target.split("x");
-			String[] candidate1Words = candidate1.split("x");
-			String[] candidate2Words = candidate2.split("x");
-
-			int difT21 = Integer.parseInt(targetWords[0]) - Integer.parseInt(candidate2Words[0]);
-			int difT22 = Integer.parseInt(targetWords[1]) - Integer.parseInt(candidate2Words[1]);
-
-			int difT11 = Integer.parseInt(targetWords[0]) - Integer.parseInt(candidate1Words[0]);
-			int difT12 = Integer.parseInt(targetWords[1]) - Integer.parseInt(candidate1Words[1]);
-
-			if (difT21 < 0)
-				difT21 = difT21 * -1;
-
-			if (difT22 < 0)
-				difT22 = difT22 * -1;
-
-			if (!(difT11 < difT21)) {
-				if (difT11 == difT21) {
-					ret = difT12 > difT22;
-				} else {
-					ret = true;
-				}
-			}
-
-			return ret;
-		}
-	}
-
-	// Compare if the resolution that comes (candidate1) is smaller than the one
-	// entered (target)
-	public boolean smaller(String target, String candidate1) {
-		String[] targetWords = target.split("x");
-		String[] candidate1Words = candidate1.split("x");
-		int difT11 = Integer.parseInt(targetWords[0]) - Integer.parseInt(candidate1Words[0]);
-		int difT12 = Integer.parseInt(targetWords[1]) - Integer.parseInt(candidate1Words[1]);
-		return (!((difT11 < 0) || (difT12 < 0)));
-	}
-
-	
-	public boolean selectBandwidth(String target, String candidate) {
-		int minDiff = Integer.parseInt(candidate);
-		int diff = Integer.parseInt(target) - Integer.parseInt(candidate);
-		//int diff = Integer.parseInt(target);
-		return (diff < minDiff);
-	}
-
-	protected boolean isSuccessCode(int code) {
-		return code >= 200 && code <= 399;
-	}
+    protected boolean isSuccessCode(int code) {
+	return code >= 200 && code <= 399;
+    }
 
 }

--- a/hls/src/test/java/com/blazemeter/jmeter/hls/logic/HlsSamplerTest.java
+++ b/hls/src/test/java/com/blazemeter/jmeter/hls/logic/HlsSamplerTest.java
@@ -135,7 +135,7 @@ public class HlsSamplerTest {
 			.thenReturn(respond4)
 			.thenReturn(respond5);
 
-		Mockito.when(parserMock.extractUriMaster(Mockito.any(String.class),Mockito.any(String.class),Mockito.any(String.class),Mockito.any(String.class),Mockito.any(String.class)))
+		Mockito.when(parserMock.extractMediaUrl(Mockito.any(String.class),Mockito.any(String.class),Mockito.any(String.class),Mockito.any(String.class),Mockito.any(String.class)))
 			.thenReturn("/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d");
 		Mockito.when(parserMock.extractVideoUrl(Mockito.any()))
 				.thenReturn(fragments);

--- a/hls/src/test/java/com/blazemeter/jmeter/hls/logic/ParserTest.java
+++ b/hls/src/test/java/com/blazemeter/jmeter/hls/logic/ParserTest.java
@@ -91,15 +91,19 @@ public class ParserTest {
 	@Test
     public void testExtractUriMaster() throws Exception{
 		
-		String res = "#EXTM3U\n#EXT-X-VERSION:4\n#EXT-X-STREAM-INF:AUDIO=\"600k\",BANDWIDTH=1395723,PROGRAM-ID=1,CODECS=\"avc1.42c01e,mp4a.40.2\",RESOLUTION=640x360,SUBTITLES=\"subs\"\n/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d\n#EXT-X-STREAM-INF:AUDIO=\"600k\",BANDWIDTH=170129,PROGRAM-ID=1,CODECS=\"avc1.42c00c,mp4a.40.2\",RESOLUTION=320x180,SUBTITLES=\"subs\"\n/videos/DianaLaufenberg_2010X/video/64k.m3u8?preroll=Thousands&uniqueId=4df94b1d\n#EXT-X-STREAM-INF:AUDIO=\"600k\",BANDWIDTH=425858,PROGRAM-ID=1,CODECS=\"avc1.42c015,mp4a.40.2\",RESOLUTION=512x288,SUBTITLES=\"subs\"\n/videos/DianaLaufenberg_2010X/video/180k.m3u8?preroll=Thousands&uniqueId=4df94b1d\n#EXT-X-STREAM-INF:AUDIO=\"600k\",BANDWIDTH=718158,PROGRAM-ID=1,CODECS=\"avc1.42c015,mp4a.40.2\",RESOLUTION=512x288,SUBTITLES=\"subs\"\n/videos/DianaLaufenberg_2010X/video/320k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
+		String res = "#EXTM3U\n#EXT-X-VERSION:4\n#EXT-X-STREAM-INF:AUDIO=\"600k\",BANDWIDTH=1395723,PROGRAM-ID=1,CODECS=\"avc1.42c01e,mp4a.40.2\",RESOLUTION=640x360,SUBTITLES=\"subs\"\n/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d\n#EXT-X-STREAM-INF:AUDIO=\"600k\",BANDWIDTH=1395723,PROGRAM-ID=1,CODECS=\"avc1.42c01e,mp4a.40.2\",RESOLUTION=640x480,SUBTITLES=\"subs\"\n/videos/DianaLaufenberg_2010X/video/680k.m3u8?preroll=Thousands&uniqueId=4df94b1d\n#EXT-X-STREAM-INF:AUDIO=\"600k\",BANDWIDTH=170129,PROGRAM-ID=1,CODECS=\"avc1.42c00c,mp4a.40.2\",RESOLUTION=320x180,SUBTITLES=\"subs\"\n/videos/DianaLaufenberg_2010X/video/64k.m3u8?preroll=Thousands&uniqueId=4df94b1d\n#EXT-X-STREAM-INF:AUDIO=\"600k\",BANDWIDTH=170129,PROGRAM-ID=1,CODECS=\"avc1.42c00c,mp4a.40.2\",RESOLUTION=280x180,SUBTITLES=\"subs\"\n/videos/DianaLaufenberg_2010X/video/56k.m3u8?preroll=Thousands&uniqueId=4df94b1d\n#EXT-X-STREAM-INF:AUDIO=\"600k\",BANDWIDTH=425858,PROGRAM-ID=1,CODECS=\"avc1.42c015,mp4a.40.2\",RESOLUTION=512x288,SUBTITLES=\"subs\"\n/videos/DianaLaufenberg_2010X/video/180k.m3u8?preroll=Thousands&uniqueId=4df94b1d\n#EXT-X-STREAM-INF:AUDIO=\"600k\",BANDWIDTH=718158,PROGRAM-ID=1,CODECS=\"avc1.42c015,mp4a.40.2\",RESOLUTION=512x288,SUBTITLES=\"subs\"\n/videos/DianaLaufenberg_2010X/video/320k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 		
 /*
 #EXTM3U
 #EXT-X-VERSION:4
 #EXT-X-STREAM-INF:AUDIO="600k",BANDWIDTH=1395723,PROGRAM-ID=1,CODECS="avc1.42c01e,mp4a.40.2",RESOLUTION=640x360,SUBTITLES="subs"
 /videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d
+#EXT-X-STREAM-INF:AUDIO="600k",BANDWIDTH=1395723,PROGRAM-ID=1,CODECS="avc1.42c01e,mp4a.40.2",RESOLUTION=640x480,SUBTITLES="subs"
+/videos/DianaLaufenberg_2010X/video/680k.m3u8?preroll=Thousands&uniqueId=4df94b1d
 #EXT-X-STREAM-INF:AUDIO="600k",BANDWIDTH=170129,PROGRAM-ID=1,CODECS="avc1.42c00c,mp4a.40.2",RESOLUTION=320x180,SUBTITLES="subs"
 /videos/DianaLaufenberg_2010X/video/64k.m3u8?preroll=Thousands&uniqueId=4df94b1d
+#EXT-X-STREAM-INF:AUDIO="600k",BANDWIDTH=170129,PROGRAM-ID=1,CODECS="avc1.42c00c,mp4a.40.2",RESOLUTION=280x180,SUBTITLES="subs"
+/videos/DianaLaufenberg_2010X/video/56k.m3u8?preroll=Thousands&uniqueId=4df94b1d
 #EXT-X-STREAM-INF:AUDIO="600k",BANDWIDTH=425858,PROGRAM-ID=1,CODECS="avc1.42c015,mp4a.40.2",RESOLUTION=512x288,SUBTITLES="subs"
 /videos/DianaLaufenberg_2010X/video/180k.m3u8?preroll=Thousands&uniqueId=4df94b1d
 #EXT-X-STREAM-INF:AUDIO="600k",BANDWIDTH=718158,PROGRAM-ID=1,CODECS="avc1.42c015,mp4a.40.2",RESOLUTION=512x288,SUBTITLES="subs"
@@ -107,12 +111,13 @@ public class ParserTest {
  */
 		
 
-		String result = p.extractMediaUrl(res, "640x360", "1395723", "customBandwidth", "customResolution");
-		String expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
+		String result = p.extractMediaUrl(res, "280x180", "170129", "customBandwidth", "customResolution");
+		String expected = "/videos/DianaLaufenberg_2010X/video/56k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(res);
 		System.out.println("***********************");
 
+		System.out.println("customBandwidth(170129), customResolution(280x180)");
 		System.out.println(result);
 		System.out.println(expected);
 		System.out.println("*********");
@@ -121,9 +126,7 @@ public class ParserTest {
 		result = p.extractMediaUrl(res, "640x360", "1395723", "customBandwidth", "customResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
-		System.out.println(res);
-		System.out.println("***********************");
-
+		System.out.println("customBandwidth(1395723), customResolution(640x360)");
 		System.out.println(result);
 		System.out.println(expected);
 		System.out.println("*********");
@@ -132,30 +135,34 @@ public class ParserTest {
 		result = p.extractMediaUrl(res, "320x180", "", "minBandwidth", "customResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/64k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
+		System.out.println("minBandwidth, customResolution(320x180)");
 		System.out.println(result);
 		System.out.println(expected);
 		System.out.println("*********");
 		assertEquals(expected, result);
 
-		result = p.extractMediaUrl(res, "640x360", "", "maxBandwidth", "customResolution");
-		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
+		result = p.extractMediaUrl(res, "640x480", "", "maxBandwidth", "customResolution");
+		expected = "/videos/DianaLaufenberg_2010X/video/680k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
+		System.out.println("maxBandwidth, customResolution(640x480)");
 		System.out.println(result);
 		System.out.println(expected);
 		System.out.println("*********");
-//		assertEquals(expected, result);
+		assertEquals(expected, result);
 
-		result = p.extractMediaUrl(res, "640x360", "1395723", "customBandwidth", "customResolution");
-		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
+		result = p.extractMediaUrl(res, "640x480", "1395723", "customBandwidth", "customResolution");
+		expected = "/videos/DianaLaufenberg_2010X/video/680k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
+		System.out.println("customBandwidth(1395723), customResolution(640x480)");
 		System.out.println(result);
 		System.out.println(expected);
 		System.out.println("*********");
 		assertEquals(expected, result);
 
 		result = p.extractMediaUrl(res, "640x360", "", "minBandwidth", "customResolution");
-		expected = "/videos/DianaLaufenberg_2010X/video/64k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
+		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
+		System.out.println("minBandwidth, customResolution(640x360)");
 		System.out.println(result);
 		System.out.println(expected);
 		System.out.println("*********");
@@ -164,46 +171,52 @@ public class ParserTest {
 		result = p.extractMediaUrl(res, "640x360", "", "maxBandwidth", "customResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
+		System.out.println("maxBandwidth, customResolution(640x360)");
 		System.out.println(result);
 		System.out.println(expected);
 		System.out.println("*********");
 		assertEquals(expected, result);
 
 		result = p.extractMediaUrl(res, "", "1395723", "customBandwidth", "maxResolution");
-		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
+		expected = "/videos/DianaLaufenberg_2010X/video/680k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
+		System.out.println("customBandwidth(1395723), maxResolution");
 		System.out.println(result);
 		System.out.println(expected);
 		System.out.println("*********");
 		assertEquals(expected, result);
 
 		result = p.extractMediaUrl(res, "", "", "minBandwidth", "maxResolution");
-		expected = "/videos/DianaLaufenberg_2010X/video/64k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
+		expected = "/videos/DianaLaufenberg_2010X/video/680k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
+		System.out.println("minBandwidth, maxResolution");
 		System.out.println(result);
 		System.out.println(expected);
 		System.out.println("*********");
 		assertEquals(expected, result);
 
 		result = p.extractMediaUrl(res, "", "", "maxBandwidth", "maxResolution");
-		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
+		expected = "/videos/DianaLaufenberg_2010X/video/680k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
+		System.out.println("maxBandwidth, maxResolution");
 		System.out.println(result);
 		System.out.println(expected);
 		System.out.println("*********");
 		assertEquals(expected, result);
 
 		result = p.extractMediaUrl(res, "", "1395723", "customBandwidth", "minResolution");
-		expected = "/videos/DianaLaufenberg_2010X/video/64k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
+		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
+		System.out.println("customBandwidth(1395723), minResolution");
 		System.out.println(result);
 		System.out.println(expected);
 		System.out.println("*********");
 		assertEquals(expected, result);
 
 		result = p.extractMediaUrl(res, "", "", "minBandwidth", "minResolution");
-		expected = "/videos/DianaLaufenberg_2010X/video/64k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
+		expected = "/videos/DianaLaufenberg_2010X/video/56k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
+		System.out.println("minBandwidth, minResolution");
 		System.out.println(result);
 		System.out.println(expected);
 		System.out.println("*********");
@@ -212,6 +225,7 @@ public class ParserTest {
 		result = p.extractMediaUrl(res, "", "", "maxBandwidth", "minResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
+		System.out.println("maxBandwidth, minResolution");
 		System.out.println(result);
 		System.out.println(expected);
 		System.out.println("*********");

--- a/hls/src/test/java/com/blazemeter/jmeter/hls/logic/ParserTest.java
+++ b/hls/src/test/java/com/blazemeter/jmeter/hls/logic/ParserTest.java
@@ -118,7 +118,7 @@ public class ParserTest {
 		System.out.println("*********");
 		assertEquals(expected, result);
 
-		result = p.extractMediaUrl(res, "720x480", "1395723", "customBandwidth", "customResolution");
+		result = p.extractMediaUrl(res, "640x360", "1395723", "customBandwidth", "customResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(res);
@@ -129,7 +129,7 @@ public class ParserTest {
 		System.out.println("*********");
 		assertEquals(expected, result);
 
-		result = p.extractMediaUrl(res, "640x360", "", "minBandwidth", "customResolution");
+		result = p.extractMediaUrl(res, "320x180", "", "minBandwidth", "customResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/64k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(result);

--- a/hls/src/test/java/com/blazemeter/jmeter/hls/logic/ParserTest.java
+++ b/hls/src/test/java/com/blazemeter/jmeter/hls/logic/ParserTest.java
@@ -107,7 +107,7 @@ public class ParserTest {
  */
 		
 
-		String result = p.extractUriMaster(res, "640x360", "1395723", "customBandwidth", "customResolution");
+		String result = p.extractMediaUrl(res, "640x360", "1395723", "customBandwidth", "customResolution");
 		String expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(res);
@@ -118,7 +118,7 @@ public class ParserTest {
 		System.out.println("*********");
 		assertEquals(expected, result);
 
-		result = p.extractUriMaster(res, "720x480", "1395723", "customBandwidth", "customResolution");
+		result = p.extractMediaUrl(res, "720x480", "1395723", "customBandwidth", "customResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(res);
@@ -129,7 +129,7 @@ public class ParserTest {
 		System.out.println("*********");
 		assertEquals(expected, result);
 
-		result = p.extractUriMaster(res, "640x360", "", "minBandwidth", "customResolution");
+		result = p.extractMediaUrl(res, "640x360", "", "minBandwidth", "customResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/64k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(result);
@@ -137,7 +137,7 @@ public class ParserTest {
 		System.out.println("*********");
 		assertEquals(expected, result);
 
-		result = p.extractUriMaster(res, "640x360", "", "maxBandwidth", "customResolution");
+		result = p.extractMediaUrl(res, "640x360", "", "maxBandwidth", "customResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(result);
@@ -145,7 +145,7 @@ public class ParserTest {
 		System.out.println("*********");
 //		assertEquals(expected, result);
 
-		result = p.extractUriMaster(res, "640x360", "1395723", "customBandwidth", "customResolution");
+		result = p.extractMediaUrl(res, "640x360", "1395723", "customBandwidth", "customResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(result);
@@ -153,7 +153,7 @@ public class ParserTest {
 		System.out.println("*********");
 		assertEquals(expected, result);
 
-		result = p.extractUriMaster(res, "640x360", "", "minBandwidth", "customResolution");
+		result = p.extractMediaUrl(res, "640x360", "", "minBandwidth", "customResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/64k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(result);
@@ -161,7 +161,7 @@ public class ParserTest {
 		System.out.println("*********");
 		assertEquals(expected, result);
 
-		result = p.extractUriMaster(res, "640x360", "", "maxBandwidth", "customResolution");
+		result = p.extractMediaUrl(res, "640x360", "", "maxBandwidth", "customResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(result);
@@ -169,7 +169,7 @@ public class ParserTest {
 		System.out.println("*********");
 		assertEquals(expected, result);
 
-		result = p.extractUriMaster(res, "", "1395723", "customBandwidth", "maxResolution");
+		result = p.extractMediaUrl(res, "", "1395723", "customBandwidth", "maxResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(result);
@@ -177,7 +177,7 @@ public class ParserTest {
 		System.out.println("*********");
 		assertEquals(expected, result);
 
-		result = p.extractUriMaster(res, "", "", "minBandwidth", "maxResolution");
+		result = p.extractMediaUrl(res, "", "", "minBandwidth", "maxResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/64k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(result);
@@ -185,7 +185,7 @@ public class ParserTest {
 		System.out.println("*********");
 		assertEquals(expected, result);
 
-		result = p.extractUriMaster(res, "", "", "maxBandwidth", "maxResolution");
+		result = p.extractMediaUrl(res, "", "", "maxBandwidth", "maxResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(result);
@@ -193,7 +193,7 @@ public class ParserTest {
 		System.out.println("*********");
 		assertEquals(expected, result);
 
-		result = p.extractUriMaster(res, "", "1395723", "customBandwidth", "minResolution");
+		result = p.extractMediaUrl(res, "", "1395723", "customBandwidth", "minResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/64k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(result);
@@ -201,7 +201,7 @@ public class ParserTest {
 		System.out.println("*********");
 		assertEquals(expected, result);
 
-		result = p.extractUriMaster(res, "", "", "minBandwidth", "minResolution");
+		result = p.extractMediaUrl(res, "", "", "minBandwidth", "minResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/64k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(result);
@@ -209,7 +209,7 @@ public class ParserTest {
 		System.out.println("*********");
 		assertEquals(expected, result);
 
-		result = p.extractUriMaster(res, "", "", "maxBandwidth", "minResolution");
+		result = p.extractMediaUrl(res, "", "", "maxBandwidth", "minResolution");
 		expected = "/videos/DianaLaufenberg_2010X/video/600k.m3u8?preroll=Thousands&uniqueId=4df94b1d";
 
 		System.out.println(result);


### PR DESCRIPTION
prior to these changes resolution was assumed to be present in the stream specification, and bandwidth selection was secondary to that matching... now bandwidth (which is required) is the primary stream selection criteria and then resolution matching occurs secondary to bandwidth. 

also some small fix to include port in construction of playlist uri.

I also tried to rename variables to be more descriptive.

the stream selection had some apparent bugs and some assumptions I was unable to fully understand (comparison of resolutions and selection of closest match logic)

happy to discuss changes as needed