### PR TITLE
Fix random reader with EMBEDDED QUOTE

### DIFF
--- a/random-csv-data-set/src/main/java/com/blazemeter/csv/CSVReader.java
+++ b/random-csv-data-set/src/main/java/com/blazemeter/csv/CSVReader.java
@@ -1,0 +1,111 @@
+package com.blazemeter.csv;
+
+import java.io.BufferedReader;
+import java.io.CharArrayWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CSVReader {
+    private enum ParserState {INITIAL, PLAIN, QUOTED, EMBEDDEDQUOTE}
+
+    public static final char QUOTING_CHAR = '"';
+
+    public static String[] csvReadFile(BufferedReader infile, char delim)
+            throws IOException {
+        int ch;
+        ParserState state = ParserState.INITIAL;
+        List<String> list = new ArrayList<>();
+        CharArrayWriterExt baos = new CharArrayWriterExt(200);
+        boolean push = false;
+        while (-1 != (ch = infile.read())) {
+            push = false;
+            switch (state) {
+                case INITIAL:
+                    if (ch == QUOTING_CHAR) {
+                        state = ParserState.QUOTED;
+                    } else if (isDelimOrEOL(delim, ch)) {
+                        push = true;
+                    } else {
+                        baos.write(ch);
+                        state = ParserState.PLAIN;
+                    }
+                    break;
+                case PLAIN:
+                    if (isDelimOrEOL(delim, ch)) {
+                        push = true;
+                        state = ParserState.INITIAL;
+                    } else {
+                        baos.write(ch);
+                    }
+                    break;
+                case QUOTED:
+                    if (ch == QUOTING_CHAR) {
+                        state = ParserState.EMBEDDEDQUOTE;
+                    }
+                    baos.write(ch);
+                    break;
+                case EMBEDDEDQUOTE:
+                    if (ch == QUOTING_CHAR) {
+                        baos.write(QUOTING_CHAR); // doubled quote => quote
+                        state = ParserState.QUOTED;
+                    } else if (isDelimOrEOL(delim, ch)) {
+                        push = true;
+                        baos.shiftLeft(1); // if current ch == delimiter -> previous char was QUOTING
+                        state = ParserState.INITIAL;
+                    } else {
+                        baos.write(ch);
+                    }
+                    break;
+                default:
+                    throw new IllegalStateException("Unexpected state " + state);
+            } // switch(state)
+            if (push) {
+                if (ch == '\r') {// Remove following \n if present
+                    infile.mark(1);
+                    if (infile.read() != '\n') {
+                        infile.reset(); // did not find \n, put the character
+                        // back
+                    }
+                }
+                String s = baos.toString();
+                list.add(s);
+                baos.reset();
+            }
+            if ((ch == '\n' || ch == '\r') && state != ParserState.QUOTED) {
+                break;
+            }
+        } // while not EOF
+        if (ch == -1) {// EOF (or end of string) so collect any remaining data
+            if (state == ParserState.QUOTED) {
+                throw new IOException("Missing trailing quote-char in quoted field:[\""
+                        + baos.toString() + "]");
+            }
+            // Do we have some data, or a trailing empty field?
+            if (baos.size() > 0 // we have some data
+                    || push // we've started a field
+                    || state == ParserState.EMBEDDEDQUOTE // Just seen ""
+                    ) {
+                list.add(baos.toString());
+            }
+        }
+        return list.toArray(new String[list.size()]);
+    }
+
+    private static boolean isDelimOrEOL(char delim, int ch) {
+        return ch == delim || ch == '\n' || ch == '\r';
+    }
+
+    protected static class CharArrayWriterExt extends CharArrayWriter {
+        public CharArrayWriterExt(int initialSize) {
+            super(initialSize);
+        }
+
+        public void shiftLeft(int pos) {
+            if (pos < 0 || pos > count) {
+                throw new IllegalArgumentException("Cannot shift left for: " + pos + " positions");
+            }
+            count -= pos;
+        }
+    }
+}

--- a/random-csv-data-set/src/main/java/com/blazemeter/csv/RandomCSVReader.java
+++ b/random-csv-data-set/src/main/java/com/blazemeter/csv/RandomCSVReader.java
@@ -1,6 +1,5 @@
 package com.blazemeter.csv;
 
-import org.apache.jmeter.save.CSVSaveService;
 import org.apache.jmeter.services.FileServer;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
@@ -83,7 +82,7 @@ public class RandomCSVReader {
 
     private void initHeader() {
         try (BufferedReader reader = new BufferedReader(createReader())) {
-            header = CSVSaveService.csvReadFile(reader, delim);
+            header = CSVReader.csvReadFile(reader, delim);
         } catch (IOException ex) {
             LOGGER.error("Cannot read CSV header ", ex);
             throw new RuntimeException("Cannot read CSV header: " + ex.getMessage(), ex);
@@ -134,7 +133,7 @@ public class RandomCSVReader {
     public String[] readNextLine() {
         try {
             curPos++;
-            return CSVSaveService.csvReadFile(consistentReader, delim);
+            return CSVReader.csvReadFile(consistentReader, delim);
         } catch (IOException ex) {
             LOGGER.error("Cannot get next record from csv file: ", ex);
             throw new RuntimeException("Cannot get next record from csv file: " + ex.getMessage(), ex);
@@ -158,7 +157,7 @@ public class RandomCSVReader {
     public String[] readLineWithSeek(long pos) {
         try {
             rbr.get().seek(pos);
-            return CSVSaveService.csvReadFile(rbr.get(), delim);
+            return CSVReader.csvReadFile(rbr.get(), delim);
         } catch (ClosedChannelException ex) {
             LOGGER.warn("The channel has been closed");
             return new String[0];
@@ -185,7 +184,7 @@ public class RandomCSVReader {
         try (BufferedReaderExt reader = new BufferedReaderExt(createReader(), encoding)) {
             long fileSize = file.length();
             while (reader.getPos() < fileSize) {
-                CSVSaveService.csvReadFile(reader, delim);
+                CSVReader.csvReadFile(reader, delim);
                 if (reader.getPos() < fileSize) {
                     offsets.add(reader.getPos());
                 }

--- a/random-csv-data-set/src/test/java/com/blazemeter/csv/RandomCSVReaderTest.java
+++ b/random-csv-data-set/src/test/java/com/blazemeter/csv/RandomCSVReaderTest.java
@@ -20,7 +20,7 @@ public class RandomCSVReaderTest {
     }
 
     @Test
-    public void testRandomReadWithHeaderAndWithoutRepeat() throws Exception {
+    public void testRandomReadWithHeaderAndWithoutRepeat() {
         String path = this.getClass().getResource("/JMeterCsvResults.csv").getPath();
 
         RandomCSVReader reader = new RandomCSVReader(path, "UTF-8", ",", true, false, false, false);
@@ -29,24 +29,45 @@ public class RandomCSVReaderTest {
                 Arrays.toString(reader.getHeader()));
 
         String timeStamps = "1393227741256,1393227741257,1393227741258";
+        String threadGroupName = "Thread Group 1-1{\n" +
+                "asdasdasdd\n" +
+                "fds\n" +
+                "fs\n" +
+                "sds}";
+        boolean isThreadGroupFound = false;
+        String[] line;
+
+
         long lineAddr;
         assertTrue(reader.hasNextRecord());
         lineAddr = reader.getNextLineAddr();
-        assertTrue(timeStamps.contains(reader.readLineWithSeek(lineAddr)[0]));
+        line = reader.readLineWithSeek(lineAddr);
+        assertTrue(timeStamps.contains(line[0]));
+        if (threadGroupName.equals(line[5])) {
+            isThreadGroupFound = true;
+        }
 
         assertTrue(reader.hasNextRecord());
         lineAddr = reader.getNextLineAddr();
-        assertTrue(timeStamps.contains(reader.readLineWithSeek(lineAddr)[0]));
+        line = reader.readLineWithSeek(lineAddr);
+        assertTrue(timeStamps.contains(line[0]));
+        if (threadGroupName.equals(line[5])) {
+            isThreadGroupFound = true;
+        }
 
         assertTrue(reader.hasNextRecord());
         lineAddr = reader.getNextLineAddr();
-        assertTrue(timeStamps.contains(reader.readLineWithSeek(lineAddr)[0]));
-
+        line = reader.readLineWithSeek(lineAddr);
+        assertTrue(timeStamps.contains(line[0]));
+        if (threadGroupName.equals(line[5])) {
+            isThreadGroupFound = true;
+        }
+        assertTrue("Thread group with name" + threadGroupName + " not found", isThreadGroupFound);
         assertFalse(reader.hasNextRecord());
     }
 
     @Test
-    public void testReadWithHeaderAndRepeat() throws Exception {
+    public void testReadWithHeaderAndRepeat() {
         String path = this.getClass().getResource("/JMeterCsvResults.csv").getPath();
 
         RandomCSVReader reader = new RandomCSVReader(path, "UTF-8", ",", false, false, true, true);
@@ -58,7 +79,13 @@ public class RandomCSVReaderTest {
         assertEquals("1393227741256", reader.readNextLine()[0]);
 
         assertTrue(reader.hasNextRecord());
-        assertEquals("1393227741257", reader.readNextLine()[0]);
+        String[] line = reader.readNextLine();
+        assertEquals("1393227741257", line[0]);
+        assertEquals("Thread Group 1-1{\n" +
+                "asdasdasdd\n" +
+                "fds\n" +
+                "fs\n" +
+                "sds}", line[5]);
 
         assertTrue(reader.hasNextRecord());
         assertEquals("1393227741258", reader.readNextLine()[0]);
@@ -74,7 +101,7 @@ public class RandomCSVReaderTest {
     }
 
     @Test
-    public void testMultiBytes() throws Exception {
+    public void testMultiBytes() {
         String path = this.getClass().getResource("/text.csv").getPath();
 
         RandomCSVReader reader = new RandomCSVReader(path, "UTF-8", ";", true, false, false, false);
@@ -96,22 +123,22 @@ public class RandomCSVReaderTest {
 
     private void assertRecord(String[] record) {
         switch (record[0]) {
-            case "Hänsel" :
+            case "Hänsel":
                 assertEquals("Mustermann", record[1]);
                 assertEquals("Einbahnstraße", record[2]);
                 assertEquals("Hamburg", record[3]);
                 break;
-            case "André" :
+            case "André":
                 assertEquals("Lecompte", record[1]);
                 assertEquals("Rue du marché", record[2]);
                 assertEquals("Moÿ-de-l'Aisne", record[3]);
                 break;
-            case "Ἀλέξανδρος" :
+            case "Ἀλέξανδρος":
                 assertEquals("Павлов", record[1]);
                 assertEquals("Большая Пироговская улица", record[2]);
                 assertEquals("Москва́", record[3]);
                 break;
-            case "בנימין" : // idea shows incorrect this line. firstname is real Benjamin -> 'בנימין'
+            case "בנימין": // idea shows incorrect this line. firstname is real Benjamin -> 'בנימין'
                 assertEquals("يعقوب", record[1]);
                 assertEquals("Street", record[2]);
                 assertEquals("Megapolis", record[3]);
@@ -122,7 +149,7 @@ public class RandomCSVReaderTest {
     }
 
     @Test
-    public void testRecordsCount() throws Exception {
+    public void testRecordsCount() {
         String path = this.getClass().getResource("/JMeterCsvResults.csv").getPath();
 
         // test random
@@ -164,7 +191,7 @@ public class RandomCSVReaderTest {
     }
 
     @Test
-    public void testTabDelimiter() throws Exception {
+    public void testTabDelimiter() {
         String path = this.getClass().getResource("/TabDelimiter.csv").getPath();
 
         RandomCSVReader reader = new RandomCSVReader(path, "UTF-8", "\t", false, false, false, false);
@@ -174,7 +201,7 @@ public class RandomCSVReaderTest {
     }
 
     @Test
-    public void testSpaceDelimiter() throws Exception {
+    public void testSpaceDelimiter() {
         String path = this.getClass().getResource("/SpaceDelimiter.csv").getPath();
 
         RandomCSVReader reader = new RandomCSVReader(path, "UTF-8", " ", false, false, false, false);
@@ -185,15 +212,15 @@ public class RandomCSVReaderTest {
 
 
     @Test
-    public void testEmptyLastLine() throws Exception {
+    public void testEmptyLastLine() {
         String path = this.getClass().getResource("/EmptyLastLine.csv").getPath();
 
         RandomCSVReader reader = new RandomCSVReader(path, "UTF-8", " ", true, true, true, false);
 
         List<String> results = new ArrayList<>();
-        results.add(Arrays.toString(new String[] {"1","2","3"}));
-        results.add(Arrays.toString(new String[] {"4","5","6"}));
-        results.add(Arrays.toString(new String[] {"7","8","9"}));
+        results.add(Arrays.toString(new String[]{"1", "2", "3"}));
+        results.add(Arrays.toString(new String[]{"4", "5", "6"}));
+        results.add(Arrays.toString(new String[]{"7", "8", "9"}));
 
         long addr;
         assertTrue(reader.hasNextRecord());
@@ -216,5 +243,79 @@ public class RandomCSVReaderTest {
 
         assertFalse(reader.hasNextRecord());
         assertEquals(0, results.size());
+    }
+
+    @Test
+    public void testInnerMultiLineXml() {
+        String path = this.getClass().getResource("/data1.csv").getPath();
+
+        RandomCSVReader reader = new RandomCSVReader(path, "UTF-8", ",", true, false, false, false);
+
+        assertEquals("[1, 2, 3]",
+                Arrays.toString(reader.getHeader()));
+
+
+        assertTrue(reader.hasNextRecord());
+        long addr = reader.getNextLineAddr();
+        String[] record = reader.readLineWithSeek(addr);
+
+        System.out.println(Arrays.toString(record));
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<jmeterTestPlan version=\"1.2\" properties=\"5.0\" jmeter=\"4.1-SNAPSHOT.20180827\">", record[1]);
+    }
+
+    @Test
+    public void testInnerSingleLineXml() {
+        String path = this.getClass().getResource("/data2.csv").getPath();
+
+        RandomCSVReader reader = new RandomCSVReader(path, "UTF-8", ",", true, false, false, false);
+
+        assertEquals("[1, 2, 3]",
+                Arrays.toString(reader.getHeader()));
+
+
+        assertTrue(reader.hasNextRecord());
+        long addr = reader.getNextLineAddr();
+        String[] record = reader.readLineWithSeek(addr);
+
+        System.out.println(Arrays.toString(record));
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<jmeterTestPlan version=\"1.2\" properties=\"5.0\" jmeter=\"4.1-SNAPSHOT.20180827\">", record[1]);
+    }
+
+    @Test
+    public void testInnerSingleLineXmlConsistentReader() {
+        String path = this.getClass().getResource("/data2.csv").getPath();
+
+        RandomCSVReader reader = new RandomCSVReader(path, "UTF-8", ",", false, false, false, false);
+
+        assertEquals("[1, 2, 3]",
+                Arrays.toString(reader.getHeader()));
+
+
+        assertTrue(reader.hasNextRecord());
+        String[] record = reader.readNextLine();
+
+        System.out.println(Arrays.toString(record));
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<jmeterTestPlan version=\"1.2\" properties=\"5.0\" jmeter=\"4.1-SNAPSHOT.20180827\">", record[1]);
+    }
+
+    @Test
+    public void testInnerMultiLineXmlConsistentReader() {
+        String path = this.getClass().getResource("/data1.csv").getPath();
+
+        RandomCSVReader reader = new RandomCSVReader(path, "UTF-8", ",", false, false, false, false);
+
+        assertEquals("[1, 2, 3]",
+                Arrays.toString(reader.getHeader()));
+
+
+        assertTrue(reader.hasNextRecord());
+        String[] record = reader.readNextLine();
+
+        System.out.println(Arrays.toString(record));
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<jmeterTestPlan version=\"1.2\" properties=\"5.0\" jmeter=\"4.1-SNAPSHOT.20180827\">", record[1]);
     }
 }

--- a/random-csv-data-set/src/test/resources/data1.csv
+++ b/random-csv-data-set/src/test/resources/data1.csv
@@ -1,0 +1,3 @@
+1,2,3
+Philadelphia,"<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="4.1-SNAPSHOT.20180827">",Minsk

--- a/random-csv-data-set/src/test/resources/data2.csv
+++ b/random-csv-data-set/src/test/resources/data2.csv
@@ -1,0 +1,2 @@
+1,2,3
+Philadelphia,<?xml version="1.0" encoding="UTF-8"?><jmeterTestPlan version="1.2" properties="5.0" jmeter="4.1-SNAPSHOT.20180827">,Minsk


### PR DESCRIPTION
JMeter CSV Data set can read line `<?xml version="1.0" encoding="UTF-8"?>`  only if config `Allow quoted data` == `FALSE` - in this case JMeter read just a line. If `TRUE` JMeter failed with the same error: https://02005652441498710889.googlegroups.com/attach/16ba7116bbfb9/jmeter-random.log?part=0.1&view=1&vt=ANaJVrHUS0Sy-gJDx9XImkWsGtI_56lL7wAdO43eJD3iyHJo8g-jTZO2fjqvWEb39_SMTUKCxJNZx1vjKxTVmwhUKP6K9eY8YMtle9scaOnaktNLAPSrmRU

My suggestion is:
1 - allow quoted data in the single line records. 
```
column1,column2,column3
value1,value2="aaa",val3
```

2 - allow embedded quoted data in the multi line records: (multi-line record should be wrapped in quote)
```
column1,column2,column3
value1,"<?xml version="1.0" encoding="UTF-8"?>
<hashTree>
</hashTree>",val3
```

Andrey what do you think about it?