### PR TITLE
Directory Listing: synchronize access to underlying iterator

### DIFF
--- a/directory-listing/src/main/java/com/blazemeter/jmeter/DirectoryListingIterator.java
+++ b/directory-listing/src/main/java/com/blazemeter/jmeter/DirectoryListingIterator.java
@@ -35,7 +35,7 @@ public class DirectoryListingIterator implements Iterator<File>{
     private Iterator<File> iterator;
     private List<File> list;
 
-    public boolean hasNext() {
+    synchronized public boolean hasNext() {
         if (!iterator.hasNext()) {
             if (isRewindOnEndOfList) {
                 if (isReReadDirectory) {
@@ -52,7 +52,7 @@ public class DirectoryListingIterator implements Iterator<File>{
         return iterator.hasNext();
     }
 
-    public File next() {
+    synchronized public File next() {
         return iterator.next();
     }
 


### PR DESCRIPTION
This will yield only unique values when sharing this config element
between multiple threads.