### PR TITLE
Add ability to stop child parallel thread without stopping the parent

### DIFF
--- a/parallel/src/main/java/com/blazemeter/jmeter/controller/JMeterThreadParallel.java
+++ b/parallel/src/main/java/com/blazemeter/jmeter/controller/JMeterThreadParallel.java
@@ -71,4 +71,9 @@ public class JMeterThreadParallel extends JMeterThread {
         log.debug("Parallel Thread was stopped. Parent thread will be stopped after parallel sampler.");
         super.stop();
     }
+
+    public void softStop() {
+        log.debug("Parallel Thread was stopped. Parent thread will NOT be stopped after parallel sampler.");
+        super.stop();
+    }
 }

--- a/parallel/src/main/java/com/blazemeter/jmeter/controller/ParallelSampler.java
+++ b/parallel/src/main/java/com/blazemeter/jmeter/controller/ParallelSampler.java
@@ -85,7 +85,8 @@ public class ParallelSampler extends AbstractSampler implements Controller, Thre
         for (TestElement ctl : controllers) {
             reqText.append(ctl.getName()).append("\n");
             JMeterThread jmThread = new JMeterThreadParallel(getTestTree(ctl), this, notifier, getGenerateParent());
-            jmThread.setThreadName("parallel " + this.getName());
+            String name = JMeterContextService.getContext().getThread() + " - " + this.getName() + " - " + ctl.getName();
+            jmThread.setThreadName(name);
             jmThread.setThreadGroup(threadGroup);
             jmThread.setEngine(JMeterContextService.getContext().getEngine());
             injectVariables(jmThread, this.getThreadContext());


### PR DESCRIPTION
We needed a way to continue onto the the next thread iteration loop when some specific requests in a child parallel thread failed. Unfortunately setting the test logical action in a JSR223 post processor within a request inside a child of the parallel controller did not have the expected behavior.

This PR, lets us do this by allowing a JSR223 processor stop the child thread without stopping the parent thread, hence we can stop all the children, which would let the parallel thread continue on. 

This PR is a stopgap that is the minimum amount of code changes required to allow us to achieve our goal, but it is in no way the ideal solution. 