### PR TITLE
Random CSV Data Set: variable substitution in filenames

### DIFF
--- a/random-csv-data-set/src/main/java/com/blazemeter/jmeter/RandomCSVDataSetConfig.java
+++ b/random-csv-data-set/src/main/java/com/blazemeter/jmeter/RandomCSVDataSetConfig.java
@@ -16,6 +16,8 @@ import org.apache.log.Logger;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThreadClone, LoopIterationListener, TestStateListener, ThreadListener {
 
@@ -34,17 +36,24 @@ public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThrea
     private final ThreadLocal<RandomCSVReader> threadLocalRandomCSVReader = new ThreadLocalSerializable<RandomCSVReader>() {
         @Override
         protected RandomCSVReader initialValue() {
-            return createRandomCSVReader();
+            return null;
         }
     };
 
     private static class ThreadLocalSerializable<T> extends ThreadLocal<T> implements Serializable {
     }
 
-    private RandomCSVReader randomCSVReader;
+    private RandomCSVReader randomCSVReader = null;
+    private String filename;	// Real filename, with substituted variables
 
     @Override
     public void iterationStart(LoopIterationEvent loopIterationEvent) {
+    	if(filename == null) {
+    		filename = getFinalFilename();
+    		randomCSVReader = createRandomCSVReader();
+    		threadLocalRandomCSVReader.set(createRandomCSVReader());
+    	}
+
         boolean isIndependentListPerThread = isIndependentListPerThread();
 
         if (!isIndependentListPerThread && randomCSVReader == null) {
@@ -56,6 +65,27 @@ public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThrea
         } else {
             readConsistent();
         }
+    }
+
+    private String getFinalFilename() {
+    	String ret = getFilename();
+
+    	JMeterVariables variables = JMeterContextService.getContext().getVariables();
+    	Pattern pattern = Pattern.compile("\\$\\{([a-z]+)\\}");
+    	Matcher matcher = pattern.matcher(ret);
+    	while(matcher.find()) {
+    		String contents;
+    		try {
+    			contents = variables.get(matcher.group(1));
+    		} catch(NullPointerException e) {
+    			contents = null;
+    		}
+
+    		if(contents != null)
+    			ret = ret.replace(matcher.group(), contents);
+    	}
+
+    	return ret;
     }
 
     private void readRandom() {
@@ -120,7 +150,7 @@ public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThrea
 
     private RandomCSVReader createRandomCSVReader() {
         return new RandomCSVReader(
-                getFilename(),
+                filename,
                 getFileEncoding(),
                 getDelimiter(),
                 isRandomOrder(),
@@ -162,9 +192,7 @@ public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThrea
     }
 
     @Override
-    public void testStarted(String s) {
-        randomCSVReader = createRandomCSVReader();
-    }
+    public void testStarted(String s) {}
 
     @Override
     public void testEnded() {

--- a/random-csv-data-set/src/main/java/com/blazemeter/jmeter/RandomCSVDataSetConfig.java
+++ b/random-csv-data-set/src/main/java/com/blazemeter/jmeter/RandomCSVDataSetConfig.java
@@ -46,14 +46,18 @@ public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThrea
     private RandomCSVReader randomCSVReader = null;
     private String filename;	// Real filename, with substituted variables
 
-    @Override
-    public void iterationStart(LoopIterationEvent loopIterationEvent) {
+    // Public: will be called from TestRandomCSVAction as well
+    public void trySetFinalFilename() {
     	if(filename == null) {
     		filename = getFinalFilename();
     		randomCSVReader = createRandomCSVReader();
     		threadLocalRandomCSVReader.set(createRandomCSVReader());
     	}
+    }
 
+    @Override
+    public void iterationStart(LoopIterationEvent loopIterationEvent) {
+    	trySetFinalFilename();
         boolean isIndependentListPerThread = isIndependentListPerThread();
 
         if (!isIndependentListPerThread && randomCSVReader == null) {

--- a/random-csv-data-set/src/main/java/com/blazemeter/jmeter/TestRandomCSVAction.java
+++ b/random-csv-data-set/src/main/java/com/blazemeter/jmeter/TestRandomCSVAction.java
@@ -46,6 +46,7 @@ public class TestRandomCSVAction implements ActionListener {
 
             final List<Map<String, String>> result = new ArrayList<>();
 
+            config.trySetFinalFilename();
             config.testStarted();
 
             String[] destinationVariableKeys = config.getDestinationVariableKeys();


### PR DESCRIPTION
This allows for filenames with JMeter variables on them, for instance, `/home/user/CSVs/${file}.csv`. The idea is to postpone the creation of the RandomCSVReader object as forward in time as possible so, when it's actually created, the referenced variable exists.