### PR TITLE
moved trySetFinalFilename() method to testStarted

### DIFF
--- a/random-csv-data-set/pom.xml
+++ b/random-csv-data-set/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.blazemeter</groupId>
     <artifactId>jmeter-plugins-random-csv-data-set</artifactId>
-    <version>0.7</version>
+    <version>0.8</version>
     <name>Random CSV Data Set</name>
     <description>Config item that allows reading CSV files in random order</description>
     <licenses>

--- a/random-csv-data-set/src/main/java/com/blazemeter/jmeter/RandomCSVDataSetConfig.java
+++ b/random-csv-data-set/src/main/java/com/blazemeter/jmeter/RandomCSVDataSetConfig.java
@@ -57,7 +57,7 @@ public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThrea
 
     @Override
     public void iterationStart(LoopIterationEvent loopIterationEvent) {
-        trySetFinalFilename();
+        
         boolean isIndependentListPerThread = isIndependentListPerThread();
 
         if (!isIndependentListPerThread && randomCSVReader == null) {
@@ -197,6 +197,7 @@ public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThrea
 
     @Override
     public void testStarted(String s) {
+        trySetFinalFilename();
     }
 
     @Override


### PR DESCRIPTION
attempt to fix bug where threads start and stop before CSV is read.  Occurs in large CSV files, moved trySetFinalname() method to testStarted override instead of iterationStarted override.

https://groups.google.com/g/jmeter-plugins/c/BkhLvelLojQ/m/K0f9n524CwAJ