### PR TITLE
Fix null pointer exception

### DIFF
--- a/random-csv-data-set/pom.xml
+++ b/random-csv-data-set/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.blazemeter</groupId>
     <artifactId>jmeter-plugins-random-csv-data-set</artifactId>
-    <version>0.8</version>
+    <version>0.9</version>
     <name>Random CSV Data Set</name>
     <description>Config item that allows reading CSV files in random order</description>
     <licenses>

--- a/random-csv-data-set/pom.xml
+++ b/random-csv-data-set/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.blazemeter</groupId>
     <artifactId>jmeter-plugins-random-csv-data-set</artifactId>
-    <version>0.7</version>
+    <version>0.8</version>
     <name>Random CSV Data Set</name>
     <description>Config item that allows reading CSV files in random order</description>
     <licenses>

--- a/random-csv-data-set/src/main/java/com/blazemeter/jmeter/RandomCSVDataSetConfig.java
+++ b/random-csv-data-set/src/main/java/com/blazemeter/jmeter/RandomCSVDataSetConfig.java
@@ -44,6 +44,7 @@ public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThrea
     }
 
     private RandomCSVReader randomCSVReader = null;
+    private RandomCSVReader initialCSVReader = null;
     private String filename;    // Real filename, with substituted variables
 
     // Public: will be called from TestRandomCSVAction as well
@@ -51,7 +52,7 @@ public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThrea
         if (filename == null) {
             filename = getFinalFilename();
             randomCSVReader = createRandomCSVReader();
-            threadLocalRandomCSVReader.set(createRandomCSVReader());
+            initialCSVReader = randomCSVReader;
         }
     }
 
@@ -172,7 +173,9 @@ public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThrea
 
     @Override
     public void threadStarted() {
-
+        if (isIndependentListPerThread()) {
+            threadLocalRandomCSVReader.set(initialCSVReader);
+        }
     }
 
     @Override

--- a/random-csv-data-set/src/main/java/com/blazemeter/jmeter/RandomCSVDataSetConfig.java
+++ b/random-csv-data-set/src/main/java/com/blazemeter/jmeter/RandomCSVDataSetConfig.java
@@ -57,7 +57,7 @@ public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThrea
 
     @Override
     public void iterationStart(LoopIterationEvent loopIterationEvent) {
-        trySetFinalFilename();
+        
         boolean isIndependentListPerThread = isIndependentListPerThread();
 
         if (!isIndependentListPerThread && randomCSVReader == null) {
@@ -197,6 +197,7 @@ public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThrea
 
     @Override
     public void testStarted(String s) {
+        trySetFinalFilename();
     }
 
     @Override


### PR DESCRIPTION
Fixes "java.lang.NullPointerException: Cannot enter synchronized block because "reader" is null" when independent list per thread is checked.  

Issue documented in the comments section of https://www.blazemeter.com/blog/introducing-the-random-csv-data-set-config-plugin-on-jmeter 

Fix also stops the csv file being read twice when trySetFinalFilename() method is invoked.
