### PR TITLE
Reduce number of file handles on csv file

### DIFF
--- a/random-csv-data-set/src/main/java/com/blazemeter/csv/RandomCSVReader.java
+++ b/random-csv-data-set/src/main/java/com/blazemeter/csv/RandomCSVReader.java
@@ -30,17 +30,15 @@ public class RandomCSVReader {
     private final ThreadLocal<RandomBufferedReader> rbr = new ThreadLocal<RandomBufferedReader>() {
         @Override
         protected RandomBufferedReader initialValue() {
-            try {
-                return new RandomBufferedReader(createReader(), new RandomAccessFile(file, "r"), encoding);
-            } catch (IOException e) {
-                LOGGER.error("Cannot create RandomBufferedReader", e);
-                throw new RuntimeException("Cannot create RandomBufferedReader", e);
-            }
+            
+            return randomBufferedReader;
         }
     };
     private Random random;
 
+    private RandomBufferedReader randomBufferedReader;
     private BufferedReader consistentReader;
+    //private BufferedReader randomReader;
     private String[] header;
 
     private boolean isSkipFirstLine;
@@ -65,6 +63,17 @@ public class RandomCSVReader {
                 initConsistentReader();
             }
             initHeader();
+
+            try {
+                
+                this.randomBufferedReader = new RandomBufferedReader(createReader(), new RandomAccessFile(file, "r"), encoding);
+
+            } catch (IOException e) {
+                LOGGER.error("Cannot create RandomBufferedReader", e);
+                throw new RuntimeException("Cannot create RandomBufferedReader", e);
+            }
+            
+
         } catch (IOException ex) {
             LOGGER.error("Cannot initialize RandomCSVReader, because of error: ", ex);
             throw new RuntimeException("Cannot initialize RandomCSVReader, because of error: " + ex.getMessage(), ex);

--- a/random-csv-data-set/src/main/java/com/blazemeter/jmeter/RandomCSVDataSetConfig.java
+++ b/random-csv-data-set/src/main/java/com/blazemeter/jmeter/RandomCSVDataSetConfig.java
@@ -180,17 +180,7 @@ public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThrea
 
     @Override
     public void threadFinished() {
-        RandomCSVReader reader = getReader();
-        if (reader != null) {
-            reader.close();
-            if (!isRandomOrder() && isIndependentListPerThread()) {
-                try {
-                    reader.closeConsistentReader();
-                } catch (IOException e) {
-                    LOGGER.warn("Failed to close Consistent Reader", e);
-                }
-            }
-        }
+
     }
 
     @Override
@@ -210,12 +200,16 @@ public class RandomCSVDataSetConfig extends ConfigTestElement implements NoThrea
 
     @Override
     public void testEnded(String s) {
-        try {
-            if (randomCSVReader != null && !isRandomOrder()) {
-                randomCSVReader.closeConsistentReader();
+        RandomCSVReader reader = getReader();
+        if (reader != null) {
+            reader.close();
+            if (!isRandomOrder() && isIndependentListPerThread()) {
+                try {
+                    reader.closeConsistentReader();
+                } catch (IOException e) {
+                    LOGGER.warn("Failed to close Consistent Reader", e);
+                }
             }
-        } catch (IOException e) {
-            LOGGER.warn("Failed to close Consistent Reader", e);
         }
         randomCSVReader = null;
     }


### PR DESCRIPTION
The number of file handles created by the Random CSV Data Set Config causes problems when using it on Cloud infrastructure, in Azure for example, file shares have a limit of 2000 file handles per file so when running high volume tests with more than 2000 threads it causes a 'Disk Quota Exceeded' exception.  This change reduces the number of file handles created on the csv file which means more threads can share the same csv data file.  